### PR TITLE
Fix null mBrightnessController

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/settings/BrightnessDialog.java
+++ b/packages/SystemUI/src/com/android/systemui/settings/BrightnessDialog.java
@@ -49,6 +49,8 @@ public class BrightnessDialog extends Activity {
         setContentView(v);
 
         final ToggleSliderView slider = findViewById(R.id.brightness_slider);
+        
+        mBrightnessController = new BrightnessController(this, slider);
     }
 
     @Override


### PR DESCRIPTION
mBrightnessController was null causing SystemUI to crash when you press Brightness level (Settings> Display> Brightness level)

https://pastebin.com/7SWWXzhz