### PR TITLE
FingerprintService: add overlay to prevent cleanup of unused fingerprints

### DIFF
--- a/core/res/res/values/fluid_config.xml
+++ b/core/res/res/values/fluid_config.xml
@@ -76,4 +76,7 @@
         <item>restart</item>
         <item>logout</item>
     </string-array>
+
+    <!-- Whether to cleanup fingerprints upon connection to the daemon and when user switches -->
+    <bool name="config_cleanupUnusedFingerprints">true</bool>
 </resources>

--- a/core/res/res/values/fluid_symbols.xml
+++ b/core/res/res/values/fluid_symbols.xml
@@ -76,4 +76,7 @@
     
     <!-- Global Actions pref list -->
     <java-symbol type="array" name="custom_config_globalActionsList" />
+
+   <!-- Whether to cleanup fingerprints upon connection to the daemon and when user switches -->
+    <java-symbol type="bool" name="config_cleanupUnusedFingerprints" />
 </resources>

--- a/services/core/java/com/android/server/biometrics/BiometricServiceBase.java
+++ b/services/core/java/com/android/server/biometrics/BiometricServiceBase.java
@@ -78,7 +78,6 @@ public abstract class BiometricServiceBase extends SystemService
 
     protected static final boolean DEBUG = true;
 
-    private static final boolean CLEANUP_UNKNOWN_TEMPLATES = true;
     private static final String KEY_LOCKOUT_RESET_USER = "lockout_reset_user";
     private static final int MSG_USER_SWITCHING = 10;
     private static final long CANCEL_TIMEOUT_LIMIT = 3000; // max wait for onCancel() from HAL,in ms
@@ -92,6 +91,7 @@ public abstract class BiometricServiceBase extends SystemService
     private final BiometricTaskStackListener mTaskStackListener = new BiometricTaskStackListener();
     private final ResetClientStateRunnable mResetClientState = new ResetClientStateRunnable();
     private final ArrayList<LockoutResetMonitor> mLockoutMonitors = new ArrayList<>();
+    private final boolean mCleanupUnusedFingerprints;
 
     protected final IStatusBarService mStatusBarService;
     protected final Map<Integer, Long> mAuthenticatorIds =
@@ -660,6 +660,8 @@ public abstract class BiometricServiceBase extends SystemService
         mPowerManager = mContext.getSystemService(PowerManager.class);
         mUserManager = UserManager.get(mContext);
         mMetricsLogger = new MetricsLogger();
+        mCleanupUnusedFingerprints = mContext.getResources().getBoolean(
+                com.android.internal.R.bool.config_cleanupUnusedFingerprints);
     }
 
     @Override
@@ -1236,7 +1238,7 @@ public abstract class BiometricServiceBase extends SystemService
      * @param userId
      */
     protected void doTemplateCleanupForUser(int userId) {
-        if (CLEANUP_UNKNOWN_TEMPLATES) {
+        if (mCleanupUnusedFingerprints) {
             enumerateUser(userId);
         }
     }


### PR DESCRIPTION
Restores Oreo behaviour.

Usage: Set config_cleanupUnusedFingerprints overlay to false

Change-Id: Id032fae5c6ae70ce57a60c6f5d3dbe0a6cd33258