### PR TITLE
BatteryService: Add VOOC charging support

### DIFF
--- a/core/java/android/os/BatteryManager.java
+++ b/core/java/android/os/BatteryManager.java
@@ -178,6 +178,13 @@ public class BatteryManager {
      */
     public static final String EXTRA_WARP_CHARGER = "warp_charger";
 
+    /**
+     * Extra for {@link android.content.Intent#ACTION_BATTERY_CHANGED}:
+     * boolean value to detect fast charging
+     * {@hide}
+     */
+    public static final String EXTRA_VOOC_CHARGER = "vooc_charger";
+
     // values for "status" field in the ACTION_BATTERY_CHANGED Intent
     public static final int BATTERY_STATUS_UNKNOWN = Constants.BATTERY_STATUS_UNKNOWN;
     public static final int BATTERY_STATUS_CHARGING = Constants.BATTERY_STATUS_CHARGING;

--- a/core/res/res/values/fluid_config.xml
+++ b/core/res/res/values/fluid_config.xml
@@ -62,6 +62,9 @@
     <!-- Whether device has warp charging support -->
     <bool name="config_hasWarpCharger">false</bool>
 
+    <!-- Whether device has VOOC charging support -->
+    <bool name="config_hasVoocCharger">false</bool>
+
     <!-- Certain sensor firmwares break with having a batch
          size set. By setting this to false, devices can opt
          out of setting a batch size, which fixes rotation. -->

--- a/core/res/res/values/fluid_symbols.xml
+++ b/core/res/res/values/fluid_symbols.xml
@@ -61,6 +61,9 @@
     <!-- Whether device has warp charging support -->
     <java-symbol type="bool" name="config_hasWarpCharger" />
 
+    <!-- Whether device has VOOC charging support -->
+    <java-symbol type="bool" name="config_hasVoocCharger" />
+
     <java-symbol type="bool" name="config_useDefaultBatchingForAccel" />
 
     <!-- Advanced reboot -->

--- a/packages/SettingsLib/src/com/android/settingslib/fuelgauge/BatteryStatus.java
+++ b/packages/SettingsLib/src/com/android/settingslib/fuelgauge/BatteryStatus.java
@@ -28,6 +28,7 @@ import static android.os.BatteryManager.EXTRA_PLUGGED;
 import static android.os.BatteryManager.EXTRA_STATUS;
 import static android.os.BatteryManager.EXTRA_DASH_CHARGER;
 import static android.os.BatteryManager.EXTRA_WARP_CHARGER;
+import static android.os.BatteryManager.EXTRA_VOOC_CHARGER;
 
 import android.content.Context;
 import android.content.Intent;
@@ -48,6 +49,7 @@ public class BatteryStatus {
     public static final int CHARGING_FAST = 2;
     public static final int CHARGING_DASH = 3;
     public static final int CHARGING_WARP = 4;
+    public static final int CHARGING_VOOC = 5;
 
     public final int status;
     public final int level;
@@ -59,10 +61,11 @@ public class BatteryStatus {
     public final float temperature;
     public final boolean dashChargeStatus;
     public final boolean warpChargeStatus;
+    public final boolean voocChargeStatus;
 
     public BatteryStatus(int status, int level, int plugged, int health,
             int maxChargingCurrent, int maxChargingVoltage,
-            int maxChargingWattage, float temperature, boolean dashChargeStatus, boolean warpChargeStatus) {
+            int maxChargingWattage, float temperature, boolean dashChargeStatus, boolean warpChargeStatus, boolean voocChargeStatus) {
         this.status = status;
         this.level = level;
         this.plugged = plugged;
@@ -73,6 +76,7 @@ public class BatteryStatus {
         this.temperature = temperature;
         this.dashChargeStatus = dashChargeStatus;
         this.warpChargeStatus = warpChargeStatus;
+        this.voocChargeStatus = voocChargeStatus;
     }
 
     public BatteryStatus(Intent batteryChangedIntent) {
@@ -83,6 +87,7 @@ public class BatteryStatus {
         temperature = batteryChangedIntent.getIntExtra(EXTRA_TEMPERATURE, -1);
         dashChargeStatus = batteryChangedIntent.getBooleanExtra(EXTRA_DASH_CHARGER, false);
         warpChargeStatus = batteryChangedIntent.getBooleanExtra(EXTRA_WARP_CHARGER, false);
+        voocChargeStatus = batteryChangedIntent.getBooleanExtra(EXTRA_VOOC_CHARGER, false);
 
         final int maxChargingMicroAmp = batteryChangedIntent.getIntExtra(EXTRA_MAX_CHARGING_CURRENT,
                 -1);
@@ -158,6 +163,7 @@ public class BatteryStatus {
                 R.integer.config_chargingFastThreshold);
         return  dashChargeStatus ? CHARGING_DASH :
                 warpChargeStatus ? CHARGING_WARP :
+                voocChargeStatus ? CHARGING_VOOC :
                 maxChargingWattage <= 0 ? CHARGING_UNKNOWN :
                 maxChargingWattage < slowThreshold ? CHARGING_SLOWLY :
                         maxChargingWattage > fastThreshold ? CHARGING_FAST :

--- a/packages/SystemUI/res/values/fluid_strings.xml
+++ b/packages/SystemUI/res/values/fluid_strings.xml
@@ -62,6 +62,10 @@
     <string name="keyguard_indication_warp_charging_time" formatted="false"><xliff:g id="percentage">%2$s</xliff:g> • Warp Charging (<xliff:g id="charging_time_left" example="4 hours and 2 minutes">%1$s</xliff:g> until full)</string>
     <string name="keyguard_plugged_in_warp_charging"><xliff:g id="percentage">%s</xliff:g>Warp Charging</string>
 
+    <!-- Indication on the keyguard that is shown when the device is charging with a VOOC charger. Should match keyguard_plugged_in_vooc_charging [CHAR LIMIT=40]-->
+    <string name="keyguard_indication_vooc_charging_time"><xliff:g id="percentage">%2$s</xliff:g> • VOOC Charging (<xliff:g id="charging_time_left" example="4 hours and 2 minutes">%1$s</xliff:g> until full)</string>
+    <string name="keyguard_plugged_in_vooc_charging"><xliff:g id="percentage">%s</xliff:g> • VOOC Charging</string>
+
     <!-- Advanced Reboot -->
     <string name="global_action_restart_advanced">Advanced</string>
     <string name="global_action_restart_recovery">Recovery</string>

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
@@ -1701,7 +1701,7 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener, Dumpab
         }
 
         // Take a guess at initial SIM state, battery status and PLMN until we get an update
-        mBatteryStatus = new BatteryStatus(BATTERY_STATUS_UNKNOWN, 100, 0, 0, 0, 0, 0, 0, false, false);
+        mBatteryStatus = new BatteryStatus(BATTERY_STATUS_UNKNOWN, 100, 0, 0, 0, 0, 0, 0, false, false, false);
 
         // Watch for interesting updates
         final IntentFilter filter = new IntentFilter();
@@ -2618,6 +2618,11 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener, Dumpab
 
         // change in warp charging while plugged in
         if (nowPluggedIn && current.warpChargeStatus != old.warpChargeStatus) {
+            return true;
+        }
+
+        // change in VOOC charging while plugged in
+        if (nowPluggedIn && current.voocChargeStatus != old.voocChargeStatus) {
             return true;
         }
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
@@ -545,6 +545,10 @@ public class KeyguardIndicationController implements StateListener,
                     chargingId = hasChargingTime
                             ? R.string.keyguard_indication_warp_charging_time
                             : R.string.keyguard_plugged_in_warp_charging;
+                case BatteryStatus.CHARGING_VOOC:
+                    chargingId = hasChargingTime
+                            ? R.string.keyguard_indication_vooc_charging_time
+                            : R.string.keyguard_plugged_in_vooc_charging;
                     break;
                 case BatteryStatus.CHARGING_SLOWLY:
                     chargingId = hasChargingTime

--- a/services/core/java/com/android/server/BatteryService.java
+++ b/services/core/java/com/android/server/BatteryService.java
@@ -185,6 +185,10 @@ public final class BatteryService extends SystemService {
     private boolean mHasWarpCharger;
     private boolean mLastWarpCharger;
 
+    private boolean mVoocCharger;
+    private boolean mHasVoocCharger;
+    private boolean mLastVoocCharger;
+
     private long mDischargeStartTime;
     private int mDischargeStartLevel;
 
@@ -220,6 +224,8 @@ public final class BatteryService extends SystemService {
                 com.android.internal.R.bool.config_hasDashCharger);
         mHasWarpCharger = mContext.getResources().getBoolean(
                 com.android.internal.R.bool.config_hasWarpCharger);
+        mHasVoocCharger = mContext.getResources().getBoolean(
+                com.android.internal.R.bool.config_hasVoocCharger);
 
         mCriticalBatteryLevel = mContext.getResources().getInteger(
                 com.android.internal.R.integer.config_criticalBatteryWarningLevel);
@@ -519,6 +525,7 @@ public final class BatteryService extends SystemService {
 
         mDashCharger = mHasDashCharger && isDashCharger();
         mWarpCharger = mHasWarpCharger && isWarpCharger();
+        mVoocCharger = mHasVoocCharger && isVoocCharger();
 
         if (force || (mHealthInfo.batteryStatus != mLastBatteryStatus ||
                 mHealthInfo.batteryHealth != mLastBatteryHealth ||
@@ -532,7 +539,8 @@ public final class BatteryService extends SystemService {
                 mHealthInfo.batteryChargeCounter != mLastChargeCounter ||
                 mInvalidCharger != mLastInvalidCharger ||
                 mDashCharger != mLastDashCharger ||
-                mWarpCharger != mLastWarpCharger)) {
+                mWarpCharger != mLastWarpCharger ||
+                mVoocCharger != mLastVoocCharger)) {
 
             if (mPlugType != mLastPlugType) {
                 if (mLastPlugType == BATTERY_PLUGGED_NONE) {
@@ -705,6 +713,7 @@ public final class BatteryService extends SystemService {
             mLastInvalidCharger = mInvalidCharger;
             mLastDashCharger = mDashCharger;
             mLastWarpCharger = mWarpCharger;
+            mLastVoocCharger = mVoocCharger;
         }
     }
 
@@ -734,6 +743,7 @@ public final class BatteryService extends SystemService {
         intent.putExtra(BatteryManager.EXTRA_CHARGE_COUNTER, mHealthInfo.batteryChargeCounter);
         intent.putExtra(BatteryManager.EXTRA_DASH_CHARGER, mDashCharger);
         intent.putExtra(BatteryManager.EXTRA_WARP_CHARGER, mWarpCharger);
+        intent.putExtra(BatteryManager.EXTRA_VOOC_CHARGER, mVoocCharger);
         if (DEBUG) {
             Slog.d(TAG, "Sending ACTION_BATTERY_CHANGED. scale:" + BATTERY_SCALE
                     + ", info:" + mHealthInfo.toString());
@@ -805,6 +815,20 @@ public final class BatteryService extends SystemService {
     private boolean isWarpCharger() {
         try {
             FileReader file = new FileReader("/sys/class/power_supply/battery/fastchg_status");
+            BufferedReader br = new BufferedReader(file);
+            String state = br.readLine();
+            br.close();
+            file.close();
+            return "1".equals(state);
+        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
+        }
+        return false;
+    }
+
+    private boolean isVoocCharger() {
+        try {
+            FileReader file = new FileReader("/sys/class/power_supply/battery/voocchg_ing");
             BufferedReader br = new BufferedReader(file);
             String state = br.readLine();
             br.close();


### PR DESCRIPTION
* Realme devices support non standard charger type, i.e vooc charger that has its own crazy charge speeds.
* Luckily vooc charger can be determined upon the value of one node, Let's use that and update user when vooc charger is conected and vooc charging is in progress.
* Also guard this via a overlay flag and set it to false by default to preserve the default aosp behaviour for non standard chargers if user uses them.
* [@dev-harsh1998]: Forward Port to Android R's fuelgauge implementation.

Co-authored-by: Harshit Jain <god@hyper-labs.tech>
Signed-off-by: kaderbava <ksbava7325@gmail.com>