### PR TITLE
DisplayManagerService: Don't spam log when display state changes

### DIFF
--- a/services/core/java/com/android/server/display/DisplayManagerService.java
+++ b/services/core/java/com/android/server/display/DisplayManagerService.java
@@ -973,7 +973,7 @@ public final class DisplayManagerService extends SystemService {
 
             int diff = device.mDebugLastLoggedDeviceInfo.diff(info);
             if (diff == DisplayDeviceInfo.DIFF_STATE) {
-                Slog.i(TAG, "Display device changed state: \"" + info.name
+                if (DEBUG) Slog.i(TAG, "Display device changed state: \"" + info.name
                         + "\", " + Display.stateToString(info.state));
                 final Optional<Integer> viewportType = getViewportType(info);
                 if (viewportType.isPresent()) {
@@ -988,7 +988,7 @@ public final class DisplayManagerService extends SystemService {
                     }
                 }
             } else if (diff != 0) {
-                Slog.i(TAG, "Display device changed: " + info);
+                if (DEBUG) Slog.i(TAG, "Display device changed: " + info);
             }
             if ((diff & DisplayDeviceInfo.DIFF_COLOR_MODE) != 0) {
                 try {


### PR DESCRIPTION
 * dynamic refresh rate devices keep switching display configuration
   for changing refresh rate and ends up spamming log way too much

Signed-off-by: Adithya R <gh0strider.2k18.reborn@gmail.com>
Change-Id: I1f75a1f88f74284ce644c1823ce60e4d67fc8691