### PR TITLE
base: SystemUI: make QS columns count configurable

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5166,6 +5166,30 @@ public final class Settings {
          * @hide
          */
         public static final String STOCK_STATUSBAR_IN_HIDE = "stock_statusbar_in_hide";
+        
+        /*
+         * Number of qs columns on landscape orientation
+         * @hide
+         */
+        public static final String QS_LAYOUT_COLUMNS_LANDSCAPE = "qs_layout_columns_landscape";
+
+         /**
+         * Number of qs columns on portrait orientation
+         * @hide
+         */
+        public static final String QS_LAYOUT_COLUMNS = "qs_layout_columns";
+
+        /**
+         * Whether to display qs tile titles in the qs panel
+         * @hide
+         */
+        public static final String QS_TILE_TITLE_VISIBILITY = "qs_tile_title_visibility";
+
+        /**
+         * Number of qs rows
+         * @hide
+         */
+        public static final String QS_LAYOUT_ROWS = "qs_layout_rows";
 
         /**
          * Keys we no longer back up under the current schema, but want to continue to
@@ -5310,6 +5334,10 @@ public final class Settings {
             PRIVATE_SETTINGS.add(FINGERPRINT_SUCCESS_VIB);
             PRIVATE_SETTINGS.add(DISPLAY_CUTOUT_MODE);
             PRIVATE_SETTINGS.add(STOCK_STATUSBAR_IN_HIDE);
+            PRIVATE_SETTINGS.add(QS_LAYOUT_COLUMNS_LANDSCAPE);
+            PRIVATE_SETTINGS.add(QS_LAYOUT_COLUMNS);
+            PRIVATE_SETTINGS.add(QS_TILE_TITLE_VISIBILITY);
+            PRIVATE_SETTINGS.add(QS_LAYOUT_ROWS);
         }
 
         /**

--- a/packages/SystemUI/res/menu/qs_customize_menu.xml
+++ b/packages/SystemUI/res/menu/qs_customize_menu.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2009 The Android Open Source Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+        <item android:id="@+id/menu_item_columns"
+              android:title="@string/qs_menu_item_columns">
+            <menu>
+                <item android:id="@+id/menu_item_columns_three"
+                      android:title="@string/qs_menu_item_columns_three"
+                      android:checkable="true" />
+                <item android:id="@+id/menu_item_columns_four"
+                      android:title="@string/qs_menu_item_columns_four"
+                      android:checkable="true" />
+                <item android:id="@+id/menu_item_columns_five"
+                      android:title="@string/qs_menu_item_columns_five"
+                      android:checkable="true" />
+                <item android:id="@+id/menu_item_columns_six"
+                      android:title="@string/qs_menu_item_columns_six"
+                      android:checkable="true" />
+                <item android:id="@+id/menu_item_columns_seven"
+                      android:title="@string/qs_menu_item_columns_seven"
+                      android:checkable="true" />
+                <item android:id="@+id/menu_item_columns_eight"
+                      android:title="@string/qs_menu_item_columns_eight"
+                      android:checkable="true" />
+            </menu>
+        </item>
+        <item android:id="@+id/menu_item_columns_landscape"
+              android:title="@string/qs_menu_item_columns_landscape">
+            <menu>
+                <item android:id="@+id/menu_item_columns_landscape_four"
+                      android:title="@string/qs_menu_item_columns_four"
+                      android:checkable="true" />
+                <item android:id="@+id/menu_item_columns_landscape_five"
+                      android:title="@string/qs_menu_item_columns_five"
+                      android:checkable="true" />
+                <item android:id="@+id/menu_item_columns_landscape_six"
+                      android:title="@string/qs_menu_item_columns_six"
+                      android:checkable="true" />
+                <item android:id="@+id/menu_item_columns_landscape_seven"
+                      android:title="@string/qs_menu_item_columns_seven"
+                      android:checkable="true" />
+                <item android:id="@+id/menu_item_columns_landscape_eight"
+                      android:title="@string/qs_menu_item_columns_eight"
+                      android:checkable="true" />
+            </menu>
+        </item>
+        <item android:id="@+id/menu_item_reset"
+              android:title="@string/qs_menu_item_reset"/>
+</menu>

--- a/packages/SystemUI/res/values/custom_strings.xml
+++ b/packages/SystemUI/res/values/custom_strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2014 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+    <!-- QS Config -->
+    <string name="qs_menu_item_columns">Columns</string>
+    <string name="qs_menu_item_columns_landscape">Columns landscape</string>
+    <string name="qs_menu_item_columns_three">3</string>
+    <string name="qs_menu_item_columns_four">4</string>
+    <string name="qs_menu_item_columns_five">5</string>
+    <string name="qs_menu_item_columns_six">6</string>
+    <string name="qs_menu_item_columns_seven">7</string>
+    <string name="qs_menu_item_columns_eight">8</string>
+    <string name="qs_menu_item_columns_nine">9</string>
+    <string name="qs_menu_item_reset">Reset</string>
+</resources>

--- a/packages/SystemUI/src/com/android/systemui/qs/DoubleLineTileLayout.kt
+++ b/packages/SystemUI/src/com/android/systemui/qs/DoubleLineTileLayout.kt
@@ -111,6 +111,8 @@ class DoubleLineTileLayout(
         updateResources()
     }
 
+    override fun updateSettings() { }
+
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
 
         mRecords.forEach {

--- a/packages/SystemUI/src/com/android/systemui/qs/PagedTileLayout.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/PagedTileLayout.java
@@ -591,4 +591,12 @@ public class PagedTileLayout extends ViewPager implements QSTileLayout {
     public interface PageListener {
         void onPageChanged(boolean isFirst);
     }
+
+    @Override
+    public void updateSettings() {
+        for (int i = 0; i < mPages.size(); i++) {
+            mPages.get(i).updateSettings();
+        }
+        distributeTiles();
+    }
 }

--- a/packages/SystemUI/src/com/android/systemui/qs/QSFragment.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSFragment.java
@@ -559,6 +559,11 @@ public class QSFragment extends LifecycleFragment implements QS, CommandQueue.Ca
         // Let the panel know the position changed and it needs to update where notifications
         // and whatnot are.
         mPanelView.onQsHeightChanged();
+
+        // when we come back from customize update
+        if (!mQSCustomizer.isCustomizing()) {
+            mQSPanel.updateSettings();
+        }
     }
 
     /**

--- a/packages/SystemUI/src/com/android/systemui/qs/QSPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSPanel.java
@@ -209,6 +209,7 @@ public class QSPanel extends LinearLayout implements Tunable, Callback, Brightne
         if (mRegularTileLayout instanceof PagedTileLayout) {
             mQsTileRevealController = new QSTileRevealController(mContext, this,
                     (PagedTileLayout) mRegularTileLayout);
+            updateSettings();
         }
         mQSLogger.logAllTilesChangeListening(mListening, getDumpableTag(), mCachedSpecs);
         updateResources();
@@ -243,7 +244,6 @@ public class QSPanel extends LinearLayout implements Tunable, Callback, Brightne
         }
         return mRegularTileLayout;
     }
-
 
     protected QSTileLayout createHorizontalTileLayout() {
         return createRegularTileLayout();
@@ -1194,6 +1194,7 @@ public class QSPanel extends LinearLayout implements Tunable, Callback, Brightne
         int getOffsetTop(TileRecord tile);
 
         boolean updateResources();
+        void updateSettings();
 
         void setListening(boolean listening);
 
@@ -1220,5 +1221,11 @@ public class QSPanel extends LinearLayout implements Tunable, Callback, Brightne
         default void setExpansion(float expansion) {}
 
         int getNumVisibleTiles();
+    }
+
+    public void updateSettings() {
+        if (mTileLayout != null) {
+            mTileLayout.updateSettings();
+        }
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/qs/QuickQSPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QuickQSPanel.java
@@ -395,6 +395,10 @@ public class QuickQSPanel extends QSPanel {
                 return getPaddingStart() + mCellMarginHorizontal;
             }
             return getPaddingStart() + column *  (mCellWidth + mCellMarginHorizontal);
+	}
+
+        @Override
+        public void updateSettings() {
         }
 
         @Override

--- a/packages/SystemUI/src/com/android/systemui/qs/TileLayout.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/TileLayout.java
@@ -3,7 +3,9 @@ package com.android.systemui.qs;
 import static com.android.systemui.util.Utils.useQsMediaPlayer;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.os.UserHandle;
 import android.provider.Settings;
 import android.util.AttributeSet;
 import android.view.View;
@@ -29,6 +31,7 @@ public class TileLayout extends ViewGroup implements QSTileLayout {
     protected int mCellMarginVertical;
     protected int mSidePadding;
     protected int mRows = 1;
+    protected int mDefaultColumns;
 
     protected final ArrayList<TileRecord> mRecords = new ArrayList<>();
     private int mCellMarginTop;
@@ -111,23 +114,20 @@ public class TileLayout extends ViewGroup implements QSTileLayout {
 
     public boolean updateResources() {
         final Resources res = mContext.getResources();
-        mResourceColumns = Math.max(1, res.getInteger(R.integer.quick_settings_num_columns));
         mCellHeight = mContext.getResources().getDimensionPixelSize(R.dimen.qs_tile_height);
         mCellMarginHorizontal = res.getDimensionPixelSize(R.dimen.qs_tile_margin_horizontal);
         mCellMarginVertical= res.getDimensionPixelSize(R.dimen.qs_tile_margin_vertical);
         mCellMarginTop = res.getDimensionPixelSize(R.dimen.qs_tile_margin_top);
         mMaxAllowedRows = Math.max(1, getResources().getInteger(R.integer.quick_settings_max_rows));
         if (mLessRows) mMaxAllowedRows = Math.max(mMinRows, mMaxAllowedRows - 1);
-        if (updateColumns()) {
-            requestLayout();
-            return true;
-        }
+        updateSettings();
         return false;
     }
 
     private boolean updateColumns() {
+        updateSettings();
         int oldColumns = mColumns;
-        mColumns = Math.min(mResourceColumns, mMaxColumns);
+        mColumns = Math.min(mColumns, mMaxColumns);
         return oldColumns != mColumns;
     }
 
@@ -236,5 +236,22 @@ public class TileLayout extends ViewGroup implements QSTileLayout {
     @Override
     public int getNumVisibleTiles() {
         return mRecords.size();
+    }
+
+    public void updateSettings() {
+        final Resources res = mContext.getResources();
+        mDefaultColumns = Math.max(1, res.getInteger(R.integer.quick_settings_num_columns));
+        boolean isPortrait = res.getConfiguration().orientation
+                == Configuration.ORIENTATION_PORTRAIT;
+        int columns = Settings.System.getIntForUser(
+                mContext.getContentResolver(), Settings.System.QS_LAYOUT_COLUMNS, mDefaultColumns,
+                UserHandle.USER_CURRENT);
+        int columnsLandscape = Settings.System.getIntForUser(
+                mContext.getContentResolver(), Settings.System.QS_LAYOUT_COLUMNS_LANDSCAPE, mDefaultColumns,
+                UserHandle.USER_CURRENT);
+        if (mColumns != (isPortrait ? columns : columnsLandscape)) {
+            mColumns = isPortrait ? columns : columnsLandscape;
+            requestLayout();
+        }
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/qs/customize/QSCustomizer.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/customize/QSCustomizer.java
@@ -21,11 +21,19 @@ import android.animation.AnimatorListenerAdapter;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Bundle;
+import android.content.res.Resources;
+import android.content.Intent;
+import android.os.UserHandle;
+import android.provider.Settings;
+import androidx.recyclerview.widget.DefaultItemAnimator;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -39,6 +47,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.android.internal.logging.UiEventLogger;
 import com.android.internal.logging.UiEventLoggerImpl;
+import com.android.settingslib.Utils;
 import com.android.systemui.R;
 import com.android.systemui.keyguard.ScreenLifecycle;
 import com.android.systemui.plugins.qs.QS;
@@ -64,7 +73,6 @@ import javax.inject.Inject;
  */
 public class QSCustomizer extends LinearLayout implements OnMenuItemClickListener {
 
-    private static final int MENU_RESET = Menu.FIRST;
     private static final String EXTRA_QS_CUSTOMIZING = "qs_customizing";
     private static final String TAG = "QSCustomizer";
 
@@ -89,6 +97,11 @@ public class QSCustomizer extends LinearLayout implements OnMenuItemClickListene
     private boolean mIsShowingNavBackdrop;
     private UiEventLogger mUiEventLogger = new UiEventLoggerImpl();
 
+    private GridLayoutManager mLayout;
+    private int mDefaultColumns;
+    private Menu mColumnsSubMenu;
+    private Menu mColumnsLandscapeSubMenu;
+
     @Inject
     public QSCustomizer(Context context, AttributeSet attrs,
             LightBarController lightBarController,
@@ -112,25 +125,40 @@ public class QSCustomizer extends LinearLayout implements OnMenuItemClickListene
             }
         });
         mToolbar.setOnMenuItemClickListener(this);
-        mToolbar.getMenu().add(Menu.NONE, MENU_RESET, 0,
-                mContext.getString(com.android.internal.R.string.reset));
+        MenuInflater menuInflater = new MenuInflater(mContext);
+        menuInflater.inflate(R.menu.qs_customize_menu, mToolbar.getMenu());
+        MenuItem menuItem = mToolbar.getMenu().findItem(R.id.menu_item_columns);
+        if (menuItem != null) {
+            mColumnsSubMenu = menuItem.getSubMenu();
+        }
+        MenuItem menuItemLand = mToolbar.getMenu().findItem(R.id.menu_item_columns_landscape);
+        if (menuItemLand != null) {
+            mColumnsLandscapeSubMenu = menuItemLand.getSubMenu();
+        }
+        updateColumnsMenu();
+        int accentColor = Utils.getColorAccentDefaultColor(context);
+        mToolbar.setTitleTextColor(accentColor);
+        mToolbar.getNavigationIcon().setTint(accentColor);
+        mToolbar.getOverflowIcon().setTint(accentColor);
         mToolbar.setTitle(R.string.qs_edit);
-        mRecyclerView = findViewById(android.R.id.list);
+        mDefaultColumns = Math.max(1,
+                    mContext.getResources().getInteger(R.integer.quick_settings_num_columns));
+        mRecyclerView = (RecyclerView) findViewById(android.R.id.list);
         mTransparentView = findViewById(R.id.customizer_transparent_view);
         mTileAdapter = new TileAdapter(getContext(), uiEventLogger);
         mTileQueryHelper = tileQueryHelper;
         mTileQueryHelper.setListener(mTileAdapter);
         mRecyclerView.setAdapter(mTileAdapter);
         mTileAdapter.getItemTouchHelper().attachToRecyclerView(mRecyclerView);
-        GridLayoutManager layout = new GridLayoutManager(getContext(), 3) {
+        mLayout = new GridLayoutManager(getContext(), mDefaultColumns) {
             @Override
             public void onInitializeAccessibilityNodeInfoForItem(RecyclerView.Recycler recycler,
                     RecyclerView.State state, View host, AccessibilityNodeInfoCompat info) {
                 // Do not read row and column every time it changes.
             }
         };
-        layout.setSpanSizeLookup(mTileAdapter.getSizeLookup());
-        mRecyclerView.setLayoutManager(layout);
+        mLayout.setSpanSizeLookup(mTileAdapter.getSizeLookup());
+        mRecyclerView.setLayoutManager(mLayout);
         mRecyclerView.addItemDecoration(mTileAdapter.getItemDecoration());
         DefaultItemAnimator animator = new DefaultItemAnimator();
         animator.setMoveDuration(TileAdapter.MOVE_DURATION);
@@ -163,6 +191,7 @@ public class QSCustomizer extends LinearLayout implements OnMenuItemClickListene
             navBackdrop.setVisibility(mIsShowingNavBackdrop ? View.VISIBLE : View.GONE);
         }
         updateNavColors();
+        updateSettings();
     }
 
     private void updateNavColors() {
@@ -230,6 +259,12 @@ public class QSCustomizer extends LinearLayout implements OnMenuItemClickListene
         if (isShown) {
             mUiEventLogger.log(QSEditEvent.QS_EDIT_CLOSED);
             isShown = false;
+            if (mColumnsSubMenu != null) {
+                mColumnsSubMenu.close();
+            }
+            if (mColumnsLandscapeSubMenu != null) {
+                mColumnsLandscapeSubMenu.close();
+            }
             mToolbar.dismissPopupMenus();
             mClipper.cancelAnimator();
             // Make sure we're not opening (because we're closing). Nobody can think we are
@@ -264,17 +299,57 @@ public class QSCustomizer extends LinearLayout implements OnMenuItemClickListene
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
-        switch (item.getItemId()) {
-            case MENU_RESET:
-                mUiEventLogger.log(QSEditEvent.QS_EDIT_RESET);
-                reset();
-                break;
+        int id = item.getItemId();
+        if (id == R.id.menu_item_reset) {
+                    mUiEventLogger.log(QSEditEvent.QS_EDIT_RESET);
+            reset();
+        } else if (id == R.id.menu_item_columns_three) {
+            Settings.System.putIntForUser(mContext.getContentResolver(),
+                    Settings.System.QS_LAYOUT_COLUMNS, 3, UserHandle.USER_CURRENT);
+        } else if (id == R.id.menu_item_columns_four) {
+            Settings.System.putIntForUser(mContext.getContentResolver(),
+                    Settings.System.QS_LAYOUT_COLUMNS, 4, UserHandle.USER_CURRENT);
+        } else if (id == R.id.menu_item_columns_five) {
+            Settings.System.putIntForUser(mContext.getContentResolver(),
+                    Settings.System.QS_LAYOUT_COLUMNS, 5, UserHandle.USER_CURRENT);
+        } else if (id == R.id.menu_item_columns_six) {
+            Settings.System.putIntForUser(mContext.getContentResolver(),
+                    Settings.System.QS_LAYOUT_COLUMNS, 6, UserHandle.USER_CURRENT);
+        } else if (id == R.id.menu_item_columns_seven) {
+            Settings.System.putIntForUser(mContext.getContentResolver(),
+                    Settings.System.QS_LAYOUT_COLUMNS, 7, UserHandle.USER_CURRENT);
+        } else if (id == R.id.menu_item_columns_eight) {
+            Settings.System.putIntForUser(mContext.getContentResolver(),
+                    Settings.System.QS_LAYOUT_COLUMNS, 8, UserHandle.USER_CURRENT);
+        } else if (id == R.id.menu_item_columns_landscape_four) {
+            Settings.System.putIntForUser(mContext.getContentResolver(),
+                    Settings.System.QS_LAYOUT_COLUMNS_LANDSCAPE, 4, UserHandle.USER_CURRENT);
+        } else if (id == R.id.menu_item_columns_landscape_five) {
+            Settings.System.putIntForUser(mContext.getContentResolver(),
+                    Settings.System.QS_LAYOUT_COLUMNS_LANDSCAPE, 5, UserHandle.USER_CURRENT);
+        } else if (id == R.id.menu_item_columns_landscape_six) {
+            Settings.System.putIntForUser(mContext.getContentResolver(),
+                    Settings.System.QS_LAYOUT_COLUMNS_LANDSCAPE, 6, UserHandle.USER_CURRENT);
+        } else if (id == R.id.menu_item_columns_landscape_seven) {
+            Settings.System.putIntForUser(mContext.getContentResolver(),
+                    Settings.System.QS_LAYOUT_COLUMNS_LANDSCAPE, 7, UserHandle.USER_CURRENT);
+        } else if (id ==  R.id.menu_item_columns_landscape_eight) {
+            Settings.System.putIntForUser(mContext.getContentResolver(),
+                    Settings.System.QS_LAYOUT_COLUMNS_LANDSCAPE, 8, UserHandle.USER_CURRENT);
         }
+        updateSettings();
         return false;
     }
 
     private void reset() {
         mTileAdapter.resetTileSpecs(mHost, QSTileHost.getDefaultSpecs(mContext));
+        Settings.System.putIntForUser(mContext.getContentResolver(),
+                Settings.System.QS_LAYOUT_COLUMNS, mDefaultColumns,
+                UserHandle.USER_CURRENT);
+        Settings.System.putIntForUser(mContext.getContentResolver(),
+                Settings.System.QS_LAYOUT_COLUMNS_LANDSCAPE, mDefaultColumns,
+                UserHandle.USER_CURRENT);
+        updateSettings();
     }
 
     private void setTileSpecs() {
@@ -368,4 +443,43 @@ public class QSCustomizer extends LinearLayout implements OnMenuItemClickListene
             mNotifQsContainer.setCustomizerAnimating(false);
         }
     };
+
+    public void updateSettings() {
+        final Resources res = mContext.getResources();
+        boolean isPortrait = res.getConfiguration().orientation
+                == Configuration.ORIENTATION_PORTRAIT;
+        int columns = Settings.System.getIntForUser(
+                mContext.getContentResolver(), Settings.System.QS_LAYOUT_COLUMNS, mDefaultColumns,
+                UserHandle.USER_CURRENT);
+        int columnsLandscape = Settings.System.getIntForUser(
+                mContext.getContentResolver(), Settings.System.QS_LAYOUT_COLUMNS_LANDSCAPE, mDefaultColumns,
+                UserHandle.USER_CURRENT);
+        mTileAdapter.setColumnCount(isPortrait ? columns : columnsLandscape);
+        mLayout.setSpanCount(isPortrait ? columns : columnsLandscape);
+        updateColumnsMenu();
+    }
+     private void updateColumnsMenu() {
+        int columns = Settings.System.getIntForUser(
+                mContext.getContentResolver(), Settings.System.QS_LAYOUT_COLUMNS, mDefaultColumns,
+                UserHandle.USER_CURRENT);
+        MenuItem menuItemThree = mToolbar.getMenu().findItem(R.id.menu_item_columns_three);
+        menuItemThree.setChecked(columns == 3);
+        MenuItem menuItemFour = mToolbar.getMenu().findItem(R.id.menu_item_columns_four);
+        menuItemFour.setChecked(columns == 4);
+        MenuItem menuItemFive = mToolbar.getMenu().findItem(R.id.menu_item_columns_five);
+        menuItemFive.setChecked(columns == 5);
+         int columnsLandscape = Settings.System.getIntForUser(
+                mContext.getContentResolver(), Settings.System.QS_LAYOUT_COLUMNS_LANDSCAPE, mDefaultColumns,
+                UserHandle.USER_CURRENT);
+        menuItemFour = mToolbar.getMenu().findItem(R.id.menu_item_columns_landscape_four);
+        menuItemFour.setChecked(columnsLandscape == 4);
+        menuItemFive = mToolbar.getMenu().findItem(R.id.menu_item_columns_landscape_five);
+        menuItemFive.setChecked(columnsLandscape == 5);
+        MenuItem menuItemSix = mToolbar.getMenu().findItem(R.id.menu_item_columns_landscape_six);
+        menuItemSix.setChecked(columnsLandscape == 6);
+        MenuItem menuItemSeven = mToolbar.getMenu().findItem(R.id.menu_item_columns_landscape_seven);
+        menuItemSeven.setChecked(columnsLandscape == 7);
+        MenuItem menuItemEight = mToolbar.getMenu().findItem(R.id.menu_item_columns_landscape_eight);
+        menuItemEight.setChecked(columnsLandscape == 8);
+    }
 }

--- a/packages/SystemUI/src/com/android/systemui/qs/customize/TileAdapter.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/customize/TileAdapter.java
@@ -595,13 +595,18 @@ public class TileAdapter extends RecyclerView.Adapter<Holder> implements TileSta
         }
     }
 
-    private final SpanSizeLookup mSizeLookup = new SpanSizeLookup() {
+    private class OmniSpanSizeLookup extends SpanSizeLookup {
+        private int mColumns = 3;
         @Override
         public int getSpanSize(int position) {
             final int type = getItemViewType(position);
-            return type == TYPE_EDIT || type == TYPE_DIVIDER || type == TYPE_HEADER ? 3 : 1;
+            return type == TYPE_EDIT || type == TYPE_DIVIDER || type == TYPE_HEADER ? mColumns : 1;
         }
-    };
+        public void setColumnCount(int columns) {
+            mColumns = columns;
+        }
+    }
+    private final OmniSpanSizeLookup mSizeLookup = new OmniSpanSizeLookup();
 
     private class TileItemDecoration extends ItemDecoration {
         private final Drawable mDrawable;
@@ -721,4 +726,8 @@ public class TileAdapter extends RecyclerView.Adapter<Holder> implements TileSta
         public void onSwiped(ViewHolder viewHolder, int direction) {
         }
     };
+
+    public void setColumnCount(int columns) {
+        mSizeLookup.setColumnCount(columns);
+    }
 }


### PR DESCRIPTION
Just a suggestion for QS columns count customisation. It's the simplest and lighter one. Just a small menu. And it works.

And add infrastructure to add more settings and
distribute them to QS panel

PS4
we must explicitly hide the columns submenu

base: SystemUI: add column count 6

now that we have hide label

base: SystemUI: qs colums menu with checkboxes

base: SystemUI add landscape qs columns config

allow max 9 columns in landscape

DennySPb: port to R

Change-Id: I401cca347da1a94f352a9ffcb99f1409ddc4d008
Signed-off-by: DennySPB <dennyspb@gmail.com>
Signed-off-by: Jackeagle <jackeagle102@gmail.com>

Author:    Marko Man <darkobas@gmail.com>
Date:      Thu Sep 19 23:18:47 2019 +0200